### PR TITLE
Update dependencies to use newer library versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ package-mode = false
 [tool.poetry.dependencies]
 python = "^3.9"
 pyformance = "^0.4"
-inventorhatmini = "^0.0.1"
-pimoroni-ioexpander = "^0.0.5"
-"RPi.GPIO" = "^0.7.1"
+inventorhatmini = ">=1.0.0"
+pimoroni-ioexpander = ">=1.0.1"
+rpi-lgpio = ">=0.4"
 
 
 [build-system]

--- a/src/main/python/boat/setup.sh
+++ b/src/main/python/boat/setup.sh
@@ -16,8 +16,8 @@ pyenv virtualenv 3.11.8 corto
 pyenv activate corto
 curl -sSL https://install.python-poetry.org | python3 -
 pip install --upgrade adafruit-blinka
-pip install inventorhatmini
-pip install RPi.GPIO
+pip install "inventorhatmini>=1.0.0"
+pip install rpi-lgpio
 sudo raspi-config nonint do_i2c 0
 pip install adafruit-circuitpython-busdevice
 pip install adafruit-circuitpython-ssd1306


### PR DESCRIPTION
## Summary
Updated project dependencies to use newer versions of hardware libraries, specifically migrating from RPi.GPIO to rpi-lgpio and updating Pimoroni libraries to their latest major versions.

## Key Changes
- **inventorhatmini**: Updated from `^0.0.1` to `>=1.0.0` (major version bump)
- **pimoroni-ioexpander**: Updated from `^0.0.5` to `>=1.0.1` (major version bump)
- **GPIO library**: Replaced `RPi.GPIO ^0.7.1` with `rpi-lgpio >=0.4` (library migration)
- Updated setup.sh installation commands to reflect new dependency versions and use the new GPIO library

## Notable Details
- The migration from RPi.GPIO to rpi-lgpio represents a shift to a more modern GPIO interface library
- Version constraints changed from caret (`^`) to greater-than-or-equal (`>=`) for more flexible dependency resolution
- Setup script updated to install the new library versions with explicit version constraints where applicable

https://claude.ai/code/session_01PwpNbGxiE3Gyy1LLCZr3uY